### PR TITLE
use .NET 5.0 for VST2 projects

### DIFF
--- a/.github/workflows/vstnet.yml
+++ b/.github/workflows/vstnet.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 5.0.100
     - uses: microsoft/setup-msbuild@v1.0.0
     - uses: nuget/setup-nuget@v1
       with:

--- a/.github/workflows/vstnet.yml
+++ b/.github/workflows/vstnet.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100
+        dotnet-version: 5.0.x
     - uses: microsoft/setup-msbuild@v1.0.0
     - uses: nuget/setup-nuget@v1
       with:

--- a/Source/Code/Jacobi.Vst.CLI/FindFiles.cs
+++ b/Source/Code/Jacobi.Vst.CLI/FindFiles.cs
@@ -12,14 +12,14 @@ namespace Jacobi.Vst.CLI
         // Manually maintain them here.
         private static readonly string[] InteropDependencies = new[]
         {
-            @"Microsoft.Extensions.Configuration\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.Configuration.dll",
-            @"Microsoft.Extensions.Configuration.Abstractions\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.Configuration.Abstractions.dll",
-            @"Microsoft.Extensions.Configuration.FileExtensions\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.Configuration.FileExtensions.dll",
-            @"Microsoft.Extensions.Configuration.Json\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.Configuration.Json.dll",
-            @"Microsoft.Extensions.FileProviders.Physical\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.FileProviders.Physical.dll",
-            @"Microsoft.Extensions.FileProviders.Abstractions\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.FileProviders.Abstractions.dll",
-            @"Microsoft.Extensions.Primitives\3.1.8\lib\netcoreapp3.1\Microsoft.Extensions.Primitives.dll",
-            @"Microsoft.Extensions.FileSystemGlobbing\3.1.8\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll",
+            @"Microsoft.Extensions.Configuration\5.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll",
+            @"Microsoft.Extensions.Configuration.Abstractions\5.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll",
+            @"Microsoft.Extensions.Configuration.FileExtensions\5.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.FileExtensions.dll",
+            @"Microsoft.Extensions.Configuration.Json\5.0.0\lib\netstandard2.1\Microsoft.Extensions.Configuration.Json.dll",
+            @"Microsoft.Extensions.FileProviders.Physical\5.0.0\lib\net5.0\Microsoft.Extensions.FileProviders.Physical.dll",
+            @"Microsoft.Extensions.FileProviders.Abstractions\5.0.0\lib\net5.0\Microsoft.Extensions.FileProviders.Abstractions.dll",
+            @"Microsoft.Extensions.Primitives\5.0.0\lib\net5.0\Microsoft.Extensions.Primitives.dll",
+            @"Microsoft.Extensions.FileSystemGlobbing\5.0.0\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll",
             @"newtonsoft.json\12.0.2\lib\netstandard2.0\Newtonsoft.Json.dll",
         };
 
@@ -64,8 +64,8 @@ namespace Jacobi.Vst.CLI
                     var platform = ToString(ProcessorArchitecture);
 
                     // TODO: detect if the assemblies are at 'lib' or 'processor architecture' level 
-                    // TODO: tfm from params (netcoreapp3.1)
-                    var path = Path.Combine(_nugetPath, kvp.Key, "lib", "netcoreapp3.1", platform);
+                    // TODO: tfm from params (net5.0)
+                    var path = Path.Combine(_nugetPath, kvp.Key, "lib", "net5.0", platform);
                     paths.AddRange(Directory.EnumerateFiles(path, "*.dll"));
 
                     var rt = kvp.Value.RuntimeTargets?.Keys.FirstOrDefault(rt => rt.Contains(platform));

--- a/Source/Code/Jacobi.Vst.CLI/Jacobi.Vst.CLI.csproj
+++ b/Source/Code/Jacobi.Vst.CLI/Jacobi.Vst.CLI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>vstnet</AssemblyName>
     <Version>2.0.0</Version>
     <Authors>Marc Jacobi</Authors>

--- a/Source/Code/Jacobi.Vst.CLI/runtimeconfig.json
+++ b/Source/Code/Jacobi.Vst.CLI/runtimeconfig.json
@@ -1,9 +1,9 @@
 {
     "runtimeOptions": {
-        "tfm": "netcoreapp3.1",
+        "tfm": "net5.0",
         "framework": {
             "name": "Microsoft.WindowsDesktop.App",
-            "version": "3.1.0"
+            "version": "5.0.0"
         }
     }
 }

--- a/Source/Code/Jacobi.Vst.Core/Jacobi.Vst.Core.csproj
+++ b/Source/Code/Jacobi.Vst.Core/Jacobi.Vst.Core.csproj
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/Code/Jacobi.Vst.Core/Jacobi.Vst.Core.csproj
+++ b/Source/Code/Jacobi.Vst.Core/Jacobi.Vst.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <Version>2.0.0</Version>

--- a/Source/Code/Jacobi.Vst.Deployment/VstNetDeploy.targets
+++ b/Source/Code/Jacobi.Vst.Deployment/VstNetDeploy.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VstNetCliExe Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">"$(MSBuildThisFileDirectory)/../tools/netcoreapp3.1/vstnet.exe"</VstNetCliExe>
+    <VstNetCliExe Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">"$(MSBuildThisFileDirectory)/../tools/net5.0/vstnet.exe"</VstNetCliExe>
     <DeployOutput>"$(TargetDir)deploy"</DeployOutput>
   </PropertyGroup>
 

--- a/Source/Code/Jacobi.Vst.Deployment/host/VST.NET-Host.nuspec
+++ b/Source/Code/Jacobi.Vst.Deployment/host/VST.NET-Host.nuspec
@@ -17,8 +17,8 @@
     <copyright>Copyright © 2008-2020 Jacobi Software</copyright>
     <tags>vst vstnet</tags>
     <dependencies>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="Microsoft.Extensions.Configuration.Json" version="3.1.8" />
+      <group targetFramework="net5.0">
+        <dependency id="Microsoft.Extensions.Configuration.Json" version="5.0.0" />
         <dependency id="NewtonSoft.Json" version="12.0.2" />
       </group>
     </dependencies>
@@ -28,21 +28,21 @@
     <file src="VST.NET2-Host.props" target="build"></file>
     <file src="..\VstNetDeploy.targets" target="build"></file>
     
-    <file src="..\..\x86\Release\Host\Jacobi.Vst.Host.Interop.dll" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\x86\Release\Host\Jacobi.Vst.Host.Interop.xml" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\netcoreapp3.1\Jacobi.Vst.Core.dll" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\netcoreapp3.1\Jacobi.Vst.Core.xml" target="lib\netcoreapp3.1\x86"></file>
+    <file src="..\..\x86\Release\Host\Jacobi.Vst.Host.Interop.dll" target="lib\net5.0\x86"></file>
+    <file src="..\..\x86\Release\Host\Jacobi.Vst.Host.Interop.xml" target="lib\net5.0\x86"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\net5.0\Jacobi.Vst.Core.dll" target="lib\net5.0\x86"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\net5.0\Jacobi.Vst.Core.xml" target="lib\net5.0\x86"></file>
     
-    <file src="..\..\x64\Release\Host\Jacobi.Vst.Host.Interop.dll" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\x64\Release\Host\Jacobi.Vst.Host.Interop.xml" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\netcoreapp3.1\Jacobi.Vst.Core.dll" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\netcoreapp3.1\Jacobi.Vst.Core.xml" target="lib\netcoreapp3.1\x64"></file>
+    <file src="..\..\x64\Release\Host\Jacobi.Vst.Host.Interop.dll" target="lib\net5.0\x64"></file>
+    <file src="..\..\x64\Release\Host\Jacobi.Vst.Host.Interop.xml" target="lib\net5.0\x64"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\net5.0\Jacobi.Vst.Core.dll" target="lib\net5.0\x64"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\net5.0\Jacobi.Vst.Core.xml" target="lib\net5.0\x64"></file>
 
     <file src="..\..\x86\Release\Host\ijwhost.dll" target="runtimes\win10-x86\native"></file>
     <file src="..\..\x64\Release\Host\ijwhost.dll" target="runtimes\win10-x64\native"></file>
 
-    <file src="..\..\Jacobi.Vst.CLI\bin\Release\netcoreapp3.1\vstnet.exe" target="tools\netcoreapp3.1"></file>
-    <file src="..\..\Jacobi.Vst.CLI\bin\Release\netcoreapp3.1\vstnet.dll" target="tools\netcoreapp3.1"></file>
-    <file src="..\..\Jacobi.Vst.CLI\bin\Release\netcoreapp3.1\vstnet.runtimeconfig.json" target="tools\netcoreapp3.1"></file>
+    <file src="..\..\Jacobi.Vst.CLI\bin\Release\net5.0\vstnet.exe" target="tools\net5.0"></file>
+    <file src="..\..\Jacobi.Vst.CLI\bin\Release\net5.0\vstnet.dll" target="tools\net5.0"></file>
+    <file src="..\..\Jacobi.Vst.CLI\bin\Release\net5.0\vstnet.runtimeconfig.json" target="tools\net5.0"></file>
   </files>
 </package>

--- a/Source/Code/Jacobi.Vst.Deployment/host/VST.NET2-Host.props
+++ b/Source/Code/Jacobi.Vst.Deployment/host/VST.NET2-Host.props
@@ -2,17 +2,17 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="Jacobi.Vst.Core" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x86\Jacobi.Vst.Core.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x86\Jacobi.Vst.Core.dll</HintPath>
     </Reference>
     <Reference Include="Jacobi.Vst.Host.Interop" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x86\Jacobi.Vst.Host.Interop.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x86\Jacobi.Vst.Host.Interop.dll</HintPath>
     </Reference>
     
     <Reference Include="Jacobi.Vst.Core" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x64\Jacobi.Vst.Core.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x64\Jacobi.Vst.Core.dll</HintPath>
     </Reference>
     <Reference Include="Jacobi.Vst.Host.Interop" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x64\Jacobi.Vst.Host.Interop.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x64\Jacobi.Vst.Host.Interop.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Source/Code/Jacobi.Vst.Deployment/host/VST.NET2-Host.targets
+++ b/Source/Code/Jacobi.Vst.Deployment/host/VST.NET2-Host.targets
@@ -6,13 +6,13 @@
     <Error  Text="$(MSBuildThisFileName) is not built for '$(Platform)'. You need to specify either platform x86 or x64." />
   </Target>
   <Target Name="InjectReference" BeforeTargets="ResolveAssemblyReferences">
-    <!--<ItemGroup Condition="('$(Platform)' == 'x86' or '$(Platform)' == 'x64') and '$(TargetFramework)'=='netcoreapp3.1'">-->
+    <!--<ItemGroup Condition="('$(Platform)' == 'x86' or '$(Platform)' == 'x64') and '$(TargetFramework)'=='net5.0'">-->
     <ItemGroup Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'x64'">
       <Reference Include="Jacobi.Vst.Core">
-        <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\$(Platform)\Jacobi.Vst.Core.dll</HintPath>
+        <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\$(Platform)\Jacobi.Vst.Core.dll</HintPath>
       </Reference>
       <Reference Include="Jacobi.Vst.Host.Interop">
-        <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\$(Platform)\Jacobi.Vst.Host.Interop.dll</HintPath>
+        <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\$(Platform)\Jacobi.Vst.Host.Interop.dll</HintPath>
       </Reference>
     </ItemGroup>
   </Target>

--- a/Source/Code/Jacobi.Vst.Deployment/plugin/VST.NET-Plugin.nuspec
+++ b/Source/Code/Jacobi.Vst.Deployment/plugin/VST.NET-Plugin.nuspec
@@ -17,9 +17,9 @@
     <copyright>Copyright © 2008-2020 Jacobi Software</copyright>
     <tags>vst vstnet</tags>
     <dependencies>
-      <group targetFramework="netcoreapp3.1">
-        <dependency id="Microsoft.Extensions.Configuration.Json" version="3.1.8" />
-        <dependency id="Microsoft.Extensions.Logging" version="3.1.8" />
+      <group targetFramework="net5.0">
+        <dependency id="Microsoft.Extensions.Configuration.Json" version="5.0.0" />
+        <dependency id="Microsoft.Extensions.Logging" version="5.0.0" />
         <dependency id="NewtonSoft.Json" version="12.0.2" />
       </group>
     </dependencies>
@@ -29,25 +29,25 @@
     <file src="VST.NET2-Plugin.props" target="build"></file>
     <file src="..\VstNetDeploy.targets" target="build"></file>
     
-    <file src="..\..\x86\Release\Plugin\Jacobi.Vst.Plugin.Interop.dll" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\x86\Release\Plugin\Jacobi.Vst.Plugin.Interop.xml" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\netcoreapp3.1\Jacobi.Vst.Core.dll" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\netcoreapp3.1\Jacobi.Vst.Core.xml" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x86\Release\netcoreapp3.1\Jacobi.Vst.Plugin.Framework.dll" target="lib\netcoreapp3.1\x86"></file>
-    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x86\Release\netcoreapp3.1\Jacobi.Vst.Plugin.Framework.xml" target="lib\netcoreapp3.1\x86"></file>
+    <file src="..\..\x86\Release\Plugin\Jacobi.Vst.Plugin.Interop.dll" target="lib\net5.0\x86"></file>
+    <file src="..\..\x86\Release\Plugin\Jacobi.Vst.Plugin.Interop.xml" target="lib\net5.0\x86"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\net5.0\Jacobi.Vst.Core.dll" target="lib\net5.0\x86"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x86\Release\net5.0\Jacobi.Vst.Core.xml" target="lib\net5.0\x86"></file>
+    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x86\Release\net5.0\Jacobi.Vst.Plugin.Framework.dll" target="lib\net5.0\x86"></file>
+    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x86\Release\net5.0\Jacobi.Vst.Plugin.Framework.xml" target="lib\net5.0\x86"></file>
 
-    <file src="..\..\x64\Release\Plugin\Jacobi.Vst.PLugin.Interop.dll" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\x64\Release\Plugin\Jacobi.Vst.PLugin.Interop.xml" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\netcoreapp3.1\Jacobi.Vst.Core.dll" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\netcoreapp3.1\Jacobi.Vst.Core.xml" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x64\Release\netcoreapp3.1\Jacobi.Vst.Plugin.Framework.dll" target="lib\netcoreapp3.1\x64"></file>
-    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x64\Release\netcoreapp3.1\Jacobi.Vst.Plugin.Framework.xml" target="lib\netcoreapp3.1\x64"></file>
+    <file src="..\..\x64\Release\Plugin\Jacobi.Vst.PLugin.Interop.dll" target="lib\net5.0\x64"></file>
+    <file src="..\..\x64\Release\Plugin\Jacobi.Vst.PLugin.Interop.xml" target="lib\net5.0\x64"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\net5.0\Jacobi.Vst.Core.dll" target="lib\net5.0\x64"></file>
+    <file src="..\..\Jacobi.Vst.Core\bin\x64\Release\net5.0\Jacobi.Vst.Core.xml" target="lib\net5.0\x64"></file>
+    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x64\Release\net5.0\Jacobi.Vst.Plugin.Framework.dll" target="lib\net5.0\x64"></file>
+    <file src="..\..\Jacobi.Vst.Plugin.Framework\bin\x64\Release\net5.0\Jacobi.Vst.Plugin.Framework.xml" target="lib\net5.0\x64"></file>
     
     <file src="..\..\x86\Release\Plugin\ijwhost.dll" target="runtimes\win10-x86\native"></file>
     <file src="..\..\x64\Release\Plugin\ijwhost.dll" target="runtimes\win10-x64\native"></file>
 
-    <file src="..\..\Jacobi.Vst.CLI\bin\Release\netcoreapp3.1\vstnet.exe" target="tools\netcoreapp3.1"></file>
-    <file src="..\..\Jacobi.Vst.CLI\bin\Release\netcoreapp3.1\vstnet.dll" target="tools\netcoreapp3.1"></file>
-    <file src="..\..\Jacobi.Vst.CLI\bin\Release\netcoreapp3.1\vstnet.runtimeconfig.json" target="tools\netcoreapp3.1"></file>
+    <file src="..\..\Jacobi.Vst.CLI\bin\Release\net5.0\vstnet.exe" target="tools\net5.0"></file>
+    <file src="..\..\Jacobi.Vst.CLI\bin\Release\net5.0\vstnet.dll" target="tools\net5.0"></file>
+    <file src="..\..\Jacobi.Vst.CLI\bin\Release\net5.0\vstnet.runtimeconfig.json" target="tools\net5.0"></file>
   </files>
 </package>

--- a/Source/Code/Jacobi.Vst.Deployment/plugin/VST.NET2-Plugin.props
+++ b/Source/Code/Jacobi.Vst.Deployment/plugin/VST.NET2-Plugin.props
@@ -2,23 +2,23 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Reference Include="Jacobi.Vst.Core" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x86\Jacobi.Vst.Core.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x86\Jacobi.Vst.Core.dll</HintPath>
     </Reference>
     <Reference Include="Jacobi.Vst.Plugin.Interop" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x86\Jacobi.Vst.Plugin.Interop.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x86\Jacobi.Vst.Plugin.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Jacobi.Vst.Plugin.Framwork" Condition="'$(Platform)' == 'x86'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x86\Jacobi.Vst.Plugin.Framework.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x86\Jacobi.Vst.Plugin.Framework.dll</HintPath>
     </Reference>
     
     <Reference Include="Jacobi.Vst.Core" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x64\Jacobi.Vst.Core.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x64\Jacobi.Vst.Core.dll</HintPath>
     </Reference>
     <Reference Include="Jacobi.Vst.Plugin.Interop" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x64\Jacobi.Vst.Plugin.Interop.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x64\Jacobi.Vst.Plugin.Interop.dll</HintPath>
     </Reference>
     <Reference Include="Jacobi.Vst.Plugin.Framework" Condition="'$(Platform)' == 'x64'">
-      <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\x64\Jacobi.Vst.Plugin.Framework.dll</HintPath>
+      <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\x64\Jacobi.Vst.Plugin.Framework.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/Source/Code/Jacobi.Vst.Deployment/plugin/VST.NET2-Plugin.targets
+++ b/Source/Code/Jacobi.Vst.Deployment/plugin/VST.NET2-Plugin.targets
@@ -6,16 +6,16 @@
     <Error  Text="$(MSBuildThisFileName) is not built for '$(Platform)'. You need to specify either platform x86 or x64." />
   </Target>
   <Target Name="InjectReference" BeforeTargets="ResolveAssemblyReferences">
-    <!--<ItemGroup Condition="('$(Platform)' == 'x86' or '$(Platform)' == 'x64') and '$(TargetFramework)'=='netcoreapp3.1'">-->
+    <!--<ItemGroup Condition="('$(Platform)' == 'x86' or '$(Platform)' == 'x64') and '$(TargetFramework)'=='net5.0'">-->
     <ItemGroup Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'x64'">
       <Reference Include="Jacobi.Vst.Core">
-        <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\$(Platform)\Jacobi.Vst.Core.dll</HintPath>
+        <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\$(Platform)\Jacobi.Vst.Core.dll</HintPath>
       </Reference>
       <Reference Include="Jacobi.Vst.Plugin.Framework">
-        <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\$(Platform)\Jacobi.Vst.Plugin.Framework.dll</HintPath>
+        <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\$(Platform)\Jacobi.Vst.Plugin.Framework.dll</HintPath>
       </Reference>
       <Reference Include="Jacobi.Vst.Plugin.Interop">
-        <HintPath>$(MSBuildThisFileDirectory)..\lib\netcoreapp3.1\$(Platform)\Jacobi.Vst.Plugin.Interop.dll</HintPath>
+        <HintPath>$(MSBuildThisFileDirectory)..\lib\net5.0\$(Platform)\Jacobi.Vst.Plugin.Interop.dll</HintPath>
       </Reference>
     </ItemGroup>
   </Target>

--- a/Source/Code/Jacobi.Vst.Interop/Jacobi.Vst.Host.Interop.vcxproj
+++ b/Source/Code/Jacobi.Vst.Interop/Jacobi.Vst.Host.Interop.vcxproj
@@ -25,7 +25,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>JacobiVstInterop</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Source/Code/Jacobi.Vst.Interop/Jacobi.Vst.Plugin.Interop.vcxproj
+++ b/Source/Code/Jacobi.Vst.Interop/Jacobi.Vst.Plugin.Interop.vcxproj
@@ -25,7 +25,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>JacobiVstInterop</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Source/Code/Jacobi.Vst.Interop/PackageDependencies.props
+++ b/Source/Code/Jacobi.Vst.Interop/PackageDependencies.props
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <!-- Maintain packages manually -->
     <PackageDir>$(USERPROFILE)\.nuget\packages\</PackageDir>
-    <MsExtConfig>$(PackageDir)microsoft.extensions.configuration\3.1.8\lib\netcoreapp3.1</MsExtConfig>
-    <MsExtConfigAbstr>$(PackageDir)microsoft.extensions.configuration.abstractions\3.1.8\lib\netcoreapp3.1</MsExtConfigAbstr>
-    <MsExtConfigFileExt>$(PackageDir)microsoft.extensions.configuration.fileextensions\3.1.8\lib\netcoreapp3.1</MsExtConfigFileExt>
-    <MsExtConfigJson>$(PackageDir)microsoft.extensions.configuration.json\3.1.8\lib\netcoreapp3.1</MsExtConfigJson>
+    <MsExtConfig>$(PackageDir)microsoft.extensions.configuration\5.0.0\lib\netstandard2.0</MsExtConfig>
+    <MsExtConfigAbstr>$(PackageDir)microsoft.extensions.configuration.abstractions\5.0.0\lib\netstandard2.0</MsExtConfigAbstr>
+    <MsExtConfigFileExt>$(PackageDir)microsoft.extensions.configuration.fileextensions\5.0.0\lib\netstandard2.0</MsExtConfigFileExt>
+    <MsExtConfigJson>$(PackageDir)microsoft.extensions.configuration.json\5.0.0\lib\netstandard2.1</MsExtConfigJson>
     <PackageDependencies>$(MsExtConfig);$(MsExtConfigAbstr);$(MsExtConfigJson);$(MsExtConfigFileExt)</PackageDependencies>
   </PropertyGroup>
 </Project>

--- a/Source/Code/Jacobi.Vst.Plugin.Framework/Jacobi.Vst.Plugin.Framework.csproj
+++ b/Source/Code/Jacobi.Vst.Plugin.Framework/Jacobi.Vst.Plugin.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
     <Authors>Marc Jacobi</Authors>

--- a/Source/Code/Jacobi.Vst.Plugin.Framework/Jacobi.Vst.Plugin.Framework.csproj
+++ b/Source/Code/Jacobi.Vst.Plugin.Framework/Jacobi.Vst.Plugin.Framework.csproj
@@ -47,8 +47,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Source/Code/Jacobi.Vst.UnitTest/Jacobi.Vst.UnitTest.csproj
+++ b/Source/Code/Jacobi.Vst.UnitTest/Jacobi.Vst.UnitTest.csproj
@@ -1,39 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+	<PropertyGroup>
+		<TargetFramework>net5.0-windows</TargetFramework>
+		<IsPackable>false</IsPackable>
+		<AssemblyVersion>2.0.0.0</AssemblyVersion>
+		<Version>2.0.0</Version>
+		<Authors>Marc Jacobi</Authors>
+		<Company>Jacobi Software</Company>
+		<Product>VST.NET</Product>
+		<Platforms>x64;x86</Platforms>
+	</PropertyGroup>
 
-    <IsPackable>false</IsPackable>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+		<PackageReference Include="coverlet.collector" Version="1.3.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-
-    <Version>2.0.0</Version>
-
-    <Authors>Marc Jacobi</Authors>
-
-    <Company>Jacobi Software</Company>
-
-    <Product>VST.NET</Product>
-
-    <Platforms>x64;x86</Platforms>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Jacobi.Vst.Core\Jacobi.Vst.Core.csproj" />
-    <ProjectReference Include="..\Jacobi.Vst.Interop\Jacobi.Vst.Host.Interop.vcxproj" />
-    <ProjectReference Include="..\Jacobi.Vst.Interop\Jacobi.Vst.Plugin.Interop.vcxproj" />
-    <ProjectReference Include="..\Jacobi.Vst.Plugin.Framework\Jacobi.Vst.Plugin.Framework.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Jacobi.Vst.Core\Jacobi.Vst.Core.csproj" />
+		<ProjectReference Include="..\Jacobi.Vst.Interop\Jacobi.Vst.Host.Interop.vcxproj" />
+		<ProjectReference Include="..\Jacobi.Vst.Interop\Jacobi.Vst.Plugin.Interop.vcxproj" />
+		<ProjectReference Include="..\Jacobi.Vst.Plugin.Framework\Jacobi.Vst.Plugin.Framework.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Source/Samples/Jacobi.Vst.Samples.Delay/Jacobi.Vst.Samples.Delay.csproj
+++ b/Source/Samples/Jacobi.Vst.Samples.Delay/Jacobi.Vst.Samples.Delay.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>2.0.0</Version>
     <Authors>Marc Jacobi</Authors>
     <Company>Jacobi Software</Company>
@@ -17,7 +17,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="VST.NET2-Plugin" Version="2.0.0-rc3" />
   </ItemGroup>
 

--- a/Source/Samples/Jacobi.Vst.Samples.Host/Jacobi.Vst.Samples.Host.csproj
+++ b/Source/Samples/Jacobi.Vst.Samples.Host/Jacobi.Vst.Samples.Host.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Version>2.0.0</Version>
     <Authors>Marc Jacobi</Authors>

--- a/Source/Samples/Jacobi.Vst.Samples.MidiNoteMapper/Jacobi.Vst.Samples.MidiNoteMapper.csproj
+++ b/Source/Samples/Jacobi.Vst.Samples.MidiNoteMapper/Jacobi.Vst.Samples.MidiNoteMapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Version>2.0.0</Version>
     <Authors>Marc Jacobi</Authors>
     <Company>Jacobi Software</Company>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="VST.NET2-Plugin" Version="2.0.0-rc3" />
   </ItemGroup>
 </Project>

--- a/Source/Samples/Jacobi.Vst.Samples.MidiNoteSampler/Jacobi.Vst.Samples.MidiNoteSampler.csproj
+++ b/Source/Samples/Jacobi.Vst.Samples.MidiNoteSampler/Jacobi.Vst.Samples.MidiNoteSampler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Version>2.0.0</Version>
     <Authors>Marc Jacobi</Authors>
     <Company>Jacobi Software</Company>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="VST.NET2-Plugin" Version="2.0.0-rc3" />
   </ItemGroup>
 </Project>

--- a/Source/Samples/Jacobi.Vst.Samples.WrapperPlugin/Jacobi.Vst.Samples.WrapperPlugin.csproj
+++ b/Source/Samples/Jacobi.Vst.Samples.WrapperPlugin/Jacobi.Vst.Samples.WrapperPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Version>2.0.0</Version>
     <Authors>Marc Jacobi</Authors>
     <Company>Jacobi Software</Company>

--- a/Source/Templates/CSharp/Jacobi.Vst.Templates.sln
+++ b/Source/Templates/CSharp/Jacobi.Vst.Templates.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.0.30128.74
+VisualStudioVersion = 16.0.5.0.0.74
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VstNetAudioPlugin", "VstNetAudioPlugin\VstNetAudioPlugin.csproj", "{018BD11B-E0EF-475C-BDB0-2C1AD11D76E8}"
 EndProject

--- a/Source/Templates/CSharp/VstNetAudioPlugin/VstNetAudioPlugin.csproj
+++ b/Source/Templates/CSharp/VstNetAudioPlugin/VstNetAudioPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Platforms>x64;x86</Platforms>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="VST.NET2-Plugin" Version="2.0.0-rc3" />
   </ItemGroup>
 

--- a/Source/Templates/CSharp/VstNetMidiPlugin/VstNetMidiPlugin.csproj
+++ b/Source/Templates/CSharp/VstNetMidiPlugin/VstNetMidiPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <Platforms>x64;x86</Platforms>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="VST.NET2-Plugin" Version="2.0.0-rc3" />
   </ItemGroup>
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -45,7 +45,7 @@ There are several plugin [Samples](https://github.com/obiwanjacobi/vst.net/tree/
 ### Loading a Plugin
 
 After you have compiled a sample -or your own- plugin it is time to load it into a host application.
-If the build was successful you should have a deploy folder at `[MyProject]\bin\[x64|x86]\[Debug|Release]\netcoreapp3.1\deploy`.
+If the build was successful you should have a deploy folder at `[MyProject]\bin\[x64|x86]\[Debug|Release]\net5.0\deploy`.
 
 > The **Deploy** folder contains everything needed to load the plugin into a host application.
 
@@ -77,7 +77,7 @@ If you have Visual Studio installed, these files are already present.
 But if you distribute your project made with VST.NET you need to install this on the client machine.
 
 As of `2.0.0-RC1` the nuget packages for plugin and host both contain a build file to create a deployment after each successful build.
-The `deploy` folder is at the same location as the project binaries: `[MyProject]\bin\[x64|x86]\[Debug|Release]\netcoreapp3.1\deploy`.
+The `deploy` folder is at the same location as the project binaries: `[MyProject]\bin\[x64|x86]\[Debug|Release]\net5.0\deploy`.
 
 ---
 


### PR DESCRIPTION
This is a seemingly successful attempt to switch from .NET Core 3.1 to .NET 5.0. As a first advantage, this allows accessing the Windows 10 Runtime from a VST, which isn't possible under .NET Core.
